### PR TITLE
Feature/specify dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ repositories {
     - add the percentages you want to the custom attributes of the CardViewGroup in the xml file
         - custom:dashboardCardHeightPercentage, custom:widthPercentage, custom:topSpacingPercentage, custom:bottomSpacingPercentage
 3. Add an xml layout (card_layout.xml) for the contents of your cards similar to app/src/main/res/layout/card_layout.xml
+    - If you would like to display a separate layout when no cards are selected, include it here as well
 4. Create a folder cardGallery with 2 files:
     - CardContent similar to app/src/main/kotlin/com/intuit/truffle/shuffle/cardGallery/CardContent.kt
         - This is your data object for the card contents
@@ -82,6 +83,7 @@ repositories {
         - Override the getViewContent() function to set the data content in the cardContent to the views in your card_layout.xml, ie. setting the text in a textView
 5. In the Activity where you'll be using this UI component,
     - Instantiate a CustomizeAdapter you just defined and pass in an arrayList of CardContents and the resource id of inside the card ie. R.layout.card_layout
+        - If you are using a separate layout for dashboard view, include it as the optional fourth parameter
     - Call setupAdapter() on the CustomizeAdapter you just created with the CardViewGroup using findViewById()
 6. Now the TruffleShuffle UI component is ready to use!
 


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : 
  - My use case calls for displaying a separate layout when no cards are selected.
I found a pretty easy way to do this without changing the core functionality at all :)

- What Changed and Why? :
  - I added an optional parameter in the CardContentAdapter constructor for the separate layout resource. If none is provided, everything works the same.
  - The new function 'toggleLayout' simply removes all the views from the CardViewGroup and inflates them based on the current galleryState. It only gets called if a separate layout was provided.
  - This function is called before the internal click happens to get the current galleryState before it changes.

#### Notable

Specifying a separate dashboard layout causes every card to be inflated every time a click happens. This gets expensive as layouts become more complex. One way to improve this feature would be to inflate all cards with the dashboard layout initially, and only change the card that is selected. I wanted to keep things simple for now, and I hope the feature is helpful!

- Type of change :
  - [x] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [ ] Add unit tests
  - [x] Add documentation