### PR TITLE
Change test framework to MockK

### DIFF
--- a/truffleshuffle/build.gradle
+++ b/truffleshuffle/build.gradle
@@ -44,8 +44,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation "io.mockk:mockk:1.10.2"
     testImplementation "org.robolectric:robolectric:4.0.2"
 }
 repositories {

--- a/truffleshuffle/src/test/java/com/intuit/truffleshuffle/CardContentAdapterTest.kt
+++ b/truffleshuffle/src/test/java/com/intuit/truffleshuffle/CardContentAdapterTest.kt
@@ -2,9 +2,8 @@ package com.intuit.truffleshuffle
 
 import android.content.Context
 import android.view.LayoutInflater
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -22,9 +21,9 @@ class CardContentAdapterTest {
         val cardContent = CardContent()
         val cardDetailsArray = arrayListOf(cardContent)
 
-        val mockContext = mock<Context>()
-        val mockLayoutInflater = mock<LayoutInflater>()
-        doReturn(mockLayoutInflater).whenever(mockContext).getSystemService(Context.LAYOUT_INFLATER_SERVICE)
+        val mockContext = mockk<Context>()
+        val mockLayoutInflater = mockk<LayoutInflater>()
+        every { mockContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE) } returns mockLayoutInflater
         val cardContentAdapter = CustomizeAdapter(cardDetailsArray, mockContext, 0)
 
         assertEquals(1, cardContentAdapter.count)
@@ -36,9 +35,9 @@ class CardContentAdapterTest {
     fun cardContentAdapterEmptyTest() {
         val cardDetailsArray = ArrayList<CardContent>()
 
-        val mockContext = mock<Context>()
-        val mockLayoutInflater = mock<LayoutInflater>()
-        doReturn(mockLayoutInflater).whenever(mockContext).getSystemService(Context.LAYOUT_INFLATER_SERVICE)
+        val mockContext = mockk<Context>()
+        val mockLayoutInflater = mockk<LayoutInflater>()
+        every { mockContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE) } returns mockLayoutInflater
         val cardContentAdapter = CustomizeAdapter(cardDetailsArray, mockContext, 0)
 
         assertEquals(0, cardContentAdapter.count)

--- a/truffleshuffle/src/test/java/com/intuit/truffleshuffle/CardViewGroupTest.kt
+++ b/truffleshuffle/src/test/java/com/intuit/truffleshuffle/CardViewGroupTest.kt
@@ -1,9 +1,11 @@
 package com.intuit.truffleshuffle
 
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.intuit.truffleshuffle.CardViewGroup.GalleryState.DASHBOARD
 import com.intuit.truffleshuffle.CardViewGroup.GalleryState.DETAIL
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -18,11 +20,15 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CardViewGroupTest {
 
-    private val cardGroup = mock<CardViewGroup> {
-        on { paddingTop } doReturn 0
-        on { measuredWidth } doReturn 1000
-        on { measuredHeight } doReturn 1700
-        on { animationDebouncer } doReturn AnimationDebouncer()
+    private val context = spyk(getInstrumentation().targetContext) {
+        every { resources } returns mockk(relaxed = true)
+    }
+
+    private val cardGroup = spyk(CardViewGroup(context)) {
+        every { paddingTop } returns 0
+        every { measuredWidth } returns 1000
+        every { measuredHeight } returns 1700
+        every { animationDebouncer } returns AnimationDebouncer()
     }
 
     @Before


### PR DESCRIPTION
#### Relevant Issues : 
closes #31

#### What Changed and Why? :

For this change I used the latest mockk version (1.10.2) and updated every test I could find that uses mockito. 
I tried to keep them structured as closely as I could to the existing tests.

I encountered some difficulty in `CardGroupViewTest` because real functions cannot be invoked on mock objects in mockk, unlike mockito. The best analogue in mockk is to use a spy - however this required constructing an actual instance of the class which requires an android context to construct. The only context available from the InstrumentationRegistry does not load resources, so I had to mock those.

A happy consequence of this approach is that the primary constructor of `CardGroupView` is now invoked in the tests, so coverage went up about 24 lines!

#### Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

#### Other:
  - [ ] Add unit tests
  - [ ] Add documentation