### PR TITLE
Accessibility: update onclick listener lambda to call view.performClick #47

### DIFF
--- a/truffleshuffle/src/main/kotlin/com/intuit/truffleshuffle/CardContentAdapter.kt
+++ b/truffleshuffle/src/main/kotlin/com/intuit/truffleshuffle/CardContentAdapter.kt
@@ -84,6 +84,7 @@ abstract class CardContentAdapter<T : Any?>(
                 return@OnTouchListener when (event.actionMasked) {
                     MotionEvent.ACTION_DOWN -> true
                     MotionEvent.ACTION_UP -> {
+                        view.performClick()
                         cardViewGroup.click(view.tag as Int)
                         true
                     }


### PR DESCRIPTION
### Description

Thanks for contributing this Pull Request. Make sure that you send in this Pull Request to the `develop` branch of this repository, add a brief description, and tag the relevant issue(s) and PR(s) below.

- Relevant Issues : Accessibility: update onclick listener lambda to call view.performClick #47

- What Changed and Why? : Updated the setOnTouchListener to call view.performClick when there is a click inside the CardContentAdapter

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ X ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

- Other:
  - [ ] Add unit tests
  - [ ] Add documentation